### PR TITLE
fix typo 'arbitraty' => 'arbitrary' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # easypick.nvim
 
-Easypick is a neovim plugin that lets you easily create Telescope pickers (see [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)) from arbitraty console commands.
+Easypick is a neovim plugin that lets you easily create Telescope pickers (see [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)) from arbitrary console commands.
 
 # installation
 


### PR DESCRIPTION
typo is also present in the main 'About' section.