### PR TITLE
Feat: introduce postfix for nvim_command

### DIFF
--- a/lua/easypick/actions.lua
+++ b/lua/easypick/actions.lua
@@ -11,18 +11,22 @@ local function run_nvim_command(prompt_bufnr, _)
 	return true
 end
 
-local function nvim_command(prefix)
+local function nvim_command(prefix, postfix)
 	if prefix == nil then
 		prefix = ''
 	else
 		prefix = prefix .. ' '
 	end
 
+	if postfix == nil then
+		postfix = ''
+  end
+
 	return function(prompt_bufnr, _)
 		actions.select_default:replace(function()
 			actions.close(prompt_bufnr)
 			local selection = action_state.get_selected_entry()
-			vim.cmd(prefix .. selection[1])
+			vim.cmd(prefix .. selection[1] .. postfix)
 		end)
 		return true
 	end


### PR DESCRIPTION
Unfortunately, a prefix in [nvim_command](https://github.com/axkirillov/easypick.nvim/blob/88d2a95eb87413f043cf21ff985a300eaaf20496/lua/easypick/actions.lua#L25) is not enough for my purposes. 

E.g. for `TermExec` the parameter `cmd=` needs to be put into `''`, particularly 

```
 action = easypick.actions.nvim_command("TermExec  cmd='bazel build ", "'"),
```

This is currently not possible when only a prefix is available.


Another option would be that `nvim_command` still only gets one parameter, but it's a string with a placeholder for injecting selected entry from finder. 

E.g. 

```
 action = easypick.actions.nvim_command("TermExec cmd='%s")
```

and then function `nvim_command` replaces that placeholder.
