### PR TITLE
Adds a Lua API for all defined pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ The default action opens a file. Specify the `action` field in your picker confi
 
 For example `'!make %s'` will insert the entry at `%s` position and execute the corresponding command
 
+## Lua API
+You can call your created pickers using lua code in two ways
+
+```lua
+local pickers = { ... }
+require("easypick").setup(pickers = pickers)
+require("easypick").one("ls", pickers)
+require("easypick").ls()
+```
+
 # recipes
 More recipes are available in [wiki](https://github.com/axkirillov/easypick.nvim/wiki)
 

--- a/lua/easypick/init.lua
+++ b/lua/easypick/init.lua
@@ -28,4 +28,5 @@ return {
 	previewers = previewers,
 	actions = actions,
 	one_off = pick.one_off,
+	one = pick.one,
 }

--- a/lua/easypick/init.lua
+++ b/lua/easypick/init.lua
@@ -7,11 +7,16 @@ if not has_telescope then
 	error('This plugin requires nvim-telescope/telescope.nvim')
 end
 
+local M = {}
+
 local setup = function(args)
 	local pickers = args.pickers
 	local picker_names = {}
 	for _, value in pairs(pickers) do
 		table.insert(picker_names, value.name)
+		M[value.name] = function()
+			pick.one(value.name, pickers)
+		end
 	end
 	local command_opts = {
 		nargs = "*",
@@ -23,10 +28,12 @@ local setup = function(args)
 	vim.api.nvim_create_user_command('Easypick', function(opts) pick.one(opts.args, pickers) end, command_opts)
 end
 
-return {
+M = vim.tbl_extend("force", M, {
 	setup = setup,
 	previewers = previewers,
 	actions = actions,
 	one_off = pick.one_off,
 	one = pick.one,
-}
+})
+
+return M


### PR DESCRIPTION
Closes #18 by exporting a predefined call of `pick.one` for every defined picker passed to `setup`. Also exports `pick.one` as `one`.

This makes it possible to call pickers with either `require("easypick").one("picker_name", pickers)` or `require("easypick").picker_name()`.